### PR TITLE
fix spin-slider logic with a manual :spin-pivot arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ comp-spin-slider (>> states :c) $ {}
   :spin-pivot $ [] 20 120
 ```
 
-> `:spin-pivot` is supposed to provide an **absolute** position of area center, which is actually center for calculating spin angles. Since PIXI does not expose absolute position of a circle easily, now we need to add by hand.
+> `:spin-pivot` is supposed to provide an **absolute** position of area center, which is actually center for calculating spin angles. Since PIXI does not expose absolute position of a circle easily, now we need to add by hand. By default, we use center of screen as a universal spin pivot.
 
 `phlox.comp.drag-point/comp-drag-point` provides a point for dragging:
 

--- a/README.md
+++ b/README.md
@@ -210,7 +210,10 @@ comp-spin-slider (>> states :c) $ {}
   :color (hslx 200 90 30)
   :on-change $ fn (value d!) (d! cursor (assoc state :c value))
   :fraction 1
+  :spin-pivot $ [] 20 120
 ```
+
+> `:spin-pivot` is supposed to provide an **absolute** position of area center, which is actually center for calculating spin angles. Since PIXI does not expose absolute position of a circle easily, now we need to add by hand.
 
 `phlox.comp.drag-point/comp-drag-point` provides a point for dragging:
 

--- a/calcit.cirru
+++ b/calcit.cirru
@@ -16809,15 +16809,15 @@
                                                               |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1641734640523)
                                                                 :data $ {}
                                                                   |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1641734640523) (:text |first)
-                                                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1641734640523) (:text |position)
+                                                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1642347707357) (:text |spin-pivot)
                                                           |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1641734640523)
                                                             :data $ {}
                                                               |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1641734640523) (:text |-)
                                                               |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1641734640523) (:text |y)
                                                               |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1641734640523)
                                                                 :data $ {}
-                                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1641734640523) (:text |first)
-                                                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1641734640523) (:text |position)
+                                                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1642348218751) (:text |last)
+                                                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1642347709075) (:text |spin-pivot)
                                       |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1641731349664)
                                         :data $ {}
                                           |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1641731349664) (:text |:pointermove)
@@ -16973,15 +16973,15 @@
                                                                           |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1641734505279)
                                                                             :data $ {}
                                                                               |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1641734505279) (:text |first)
-                                                                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1641734505279) (:text |position)
+                                                                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1642347713903) (:text |spin-pivot)
                                                                       |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1641734506832)
                                                                         :data $ {}
                                                                           |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1641734506832) (:text |-)
                                                                           |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1641734506832) (:text |y)
                                                                           |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1641734506832)
                                                                             :data $ {}
-                                                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1641734506832) (:text |first)
-                                                                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1641734506832) (:text |position)
+                                                                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1642348221676) (:text |last)
+                                                                              |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1642347715001) (:text |spin-pivot)
                                                               |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1641734508806)
                                                                 :data $ {}
                                                                   |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1641734510734) (:text |prev-point)
@@ -17166,6 +17166,29 @@
                                   |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1641733781609) (:text |[])
                                   |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1641733782686) (:text |0)
                                   |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1641733782974) (:text |0)
+                      |yv $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1641733771364)
+                        :data $ {}
+                          |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1642347596457) (:text |spin-pivot)
+                          |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1641733772881)
+                            :data $ {}
+                              |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1641733775529) (:text |either)
+                              |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1641733776137)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1642347598701) (:text |:spin-pivot)
+                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1641733780570) (:text |props)
+                              |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1641733781334)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1641733781609) (:text |[])
+                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1642347616495)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1642347614811) (:text |js/window.innerWidth)
+                                      |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1642347618100) (:text |*)
+                                      |L $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1642347619117) (:text |0.5)
+                                  |n $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1642347616495)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1642347625315) (:text |js/window.innerHeight)
+                                      |D $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1642347618100) (:text |*)
+                                      |L $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1642347619117) (:text |0.5)
                       |T $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1641731438527)
                         :data $ {}
                           |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1641731438527) (:text |cursor)
@@ -19509,6 +19532,18 @@
                           |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1641731411694)
                             :data $ {}
                               |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1641731412024) (:text |{})
+                              |b $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1641733821120)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1641733823320) (:text |:position)
+                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1641733824117)
+                                    :data $ {}
+                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1641733824814) (:text |[])
+                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1641733825568) (:text |240)
+                                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1641733826089) (:text |240)
+                              |f $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1641733821120)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1642347759222) (:text |:spin-pivot)
+                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1642347803639) (:text |nil)
                               |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1641733668913)
                                 :data $ {}
                                   |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1641733669622) (:text |:value)
@@ -19516,6 +19551,10 @@
                                     :data $ {}
                                       |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1641733675510) (:text |:v1)
                                       |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1641733676276) (:text |state)
+                              |n $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1641733714149)
+                                :data $ {}
+                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1641733715707) (:text |:unit)
+                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1641736781617) (:text |1)
                               |r $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1641733677263)
                                 :data $ {}
                                   |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1641733685678) (:text |:on-change)
@@ -19536,18 +19575,6 @@
                                               |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1641734270548) (:text |state)
                                               |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1641734275097) (:text |:v1)
                                               |v $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1641734272667) (:text |v)
-                              |n $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1641733714149)
-                                :data $ {}
-                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1641733715707) (:text |:unit)
-                                  |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1641736781617) (:text |1)
-                              |b $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1641733821120)
-                                :data $ {}
-                                  |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1641733823320) (:text |:position)
-                                  |j $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1641733824117)
-                                    :data $ {}
-                                      |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1641733824814) (:text |[])
-                                      |j $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1641733825568) (:text |240)
-                                      |r $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1641733826089) (:text |240)
                               |v $ {} (:type :expr) (:by |rJG4IHzWf) (:at 1641736204485)
                                 :data $ {}
                                   |T $ {} (:type :leaf) (:by |rJG4IHzWf) (:at 1641736205974) (:text |:min)

--- a/compact.cirru
+++ b/compact.cirru
@@ -1296,6 +1296,8 @@
                 alpha $ either (:alpha props) 1
                 on-change $ :on-change props
                 position $ either (:position props) ([] 0 0)
+                spin-pivot $ either (:spin-pivot props)
+                  [] (* 0.5 js/window.innerWidth) (* 0.5 js/window.innerHeight)
               container
                 {} $ :position position
                 circle $ {} (:radius radius)
@@ -1308,8 +1310,8 @@
                           x $ -> e .-data .-global .-x
                           y $ -> e .-data .-global .-y
                         reset! *prev-spin-point $ []
-                          - x $ first position
-                          - y $ first position
+                          - x $ first spin-pivot
+                          - y $ last spin-pivot
                         d! cursor $ assoc state :dragging? true
                     :pointermove $ fn (e d!)
                       let
@@ -1318,8 +1320,8 @@
                         if (:dragging? state)
                           let
                               current-point $ []
-                                - x $ first position
-                                - y $ first position
+                                - x $ first spin-pivot
+                                - y $ last spin-pivot
                               prev-point @*prev-spin-point
                             if
                               < (vec-length current-point) (&* 0.5 radius)
@@ -1533,6 +1535,7 @@
                 comp-spin-slider (>> states :demo)
                   {}
                     :position $ [] 240 240
+                    :spin-pivot nil
                     :value $ :v1 state
                     :unit 1
                     :on-change $ fn (v d!)


### PR DESCRIPTION
无奈了. 事件获取到的位置是绝对位置, 但是之前往 `spin-slider` 传的数据是相对位置, 所以计算在有位置移动的情况下是会出错的. 所以只能手动处理了. 基于 PIXI 当前提供的数据没有想到好办法. 后边还得再想想.
